### PR TITLE
Use ~ for pre-release versions for proper debian package version comp…

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -116,7 +116,9 @@ var getDefaults = function (data, callback) {
       genericName: pkg.genericName || pkg.productName || pkg.name,
       description: pkg.description,
       productDescription: pkg.productDescription || pkg.description,
-      version: pkg.version || '0.0.0',
+      // Use '~' on pre-releases for proper debain version ordering.
+      // See https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
+      version: (pkg.version || '0.0.0').replace(/(\d)[_\.\-\+]?((RC|rc|pre|dev|beta|alpha)[_\.\-\+]?\d*)$/, '$1~$2'),
       revision: pkg.revision || '1',
 
       section: 'utils',


### PR DESCRIPTION
…arison

According to debian versioning, 1.0.0-beta.15-1 > 1.0.0-1. The correct thing to do for beta/rc/etc. is 1.0.0~beta.15-1.

Fixes #44