### PR TITLE
Install binary files to /usr/lib/ instead of /usr/share/

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ For example, providing this configuration:
 Will create a package with the following symlink:
 
 ```
-usr/bin/foo@ -> ../share/foo/resources/cli/launcher/sh
+usr/bin/foo@ -> ../lib/foo/resources/cli/launcher.sh
 ```
 
 And a desktop specification with the following `Exec` key:

--- a/src/installer.js
+++ b/src/installer.js
@@ -236,7 +236,7 @@ var createControl = function (options, dir, callback) {
  */
 var createBinary = function (options, dir, callback) {
   var binDir = path.join(dir, 'usr/bin')
-  var binSrc = path.join('../share', options.name, options.bin)
+  var binSrc = path.join('../lib', options.name, options.bin)
   var binDest = path.join(binDir, options.name)
   options.logger('Symlinking binary from ' + binSrc + ' to ' + binDest)
 
@@ -338,7 +338,7 @@ var createOverrides = function (options, dir, callback) {
  * Copy the application into the package.
  */
 var createApplication = function (options, dir, callback) {
-  var applicationDir = path.join(dir, 'usr/share', options.name)
+  var applicationDir = path.join(dir, 'usr/lib', options.name)
   options.logger('Copying application to ' + applicationDir)
 
   async.waterfall([


### PR DESCRIPTION
According to FSH and debian policy, /usr/share/ is for architecture-independent files only.
The correct place to install mixed architecture-dependent and architecture-independent files
is in /usr/lib/.

Fixes #46 