### PR TITLE
refactor(installer): return more-helpful error message on fakeroot ENOENT

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -45,10 +45,14 @@ var spawn = function (options, command, args, callback) {
 
   spawnedProcess.on('error', function (err) {
     if (err.name === 'ENOENT') {
-      var installer = process.platform === 'darwin' ? 'brew' : 'apt-get'
+      var isFakeroot = err.syscall === 'spawn fakeroot'
+      var isDpkg = !isFakeroot && err.syscall === 'spawn dpkg'
 
-      if (err.message.indexOf('fakeroot') > -1) {
-        err.message = 'Your system is missing the fakeroot package. Try  e.g. `' + installer + ' install fakeroot`'
+      if (isFakeroot || isDpkg) {
+        var installer = process.platform === 'darwin' ? 'brew' : 'apt-get'
+        var pkg = isFakeroot ? 'fakeroot' : 'dpkg'
+
+        err.message = 'Your system is missing the fakeroot package. Try  e.g. `' + installer + ' install ' + pkg + '`'
       }
     }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -44,11 +44,11 @@ var spawn = function (options, command, args, callback) {
   })
 
   spawnedProcess.on('error', function (err) {
-    if (err.name = 'ENOENT') {
+    if (err.name === 'ENOENT') {
       var installer = process.platform === 'darwin' ? 'brew' : 'apt-get'
 
       if (err.message.indexOf('fakeroot') > -1) {
-        err.message = 'Your system is missing the fakeroot package. Try ' + installer + ' install fakeroot'
+        err.message = 'Your system is missing the fakeroot package. Try  e.g. `' + installer + ' install fakeroot`'
       }
     }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -44,6 +44,14 @@ var spawn = function (options, command, args, callback) {
   })
 
   spawnedProcess.on('error', function (err) {
+    if (err.name = 'ENOENT') {
+      var installer = process.platform === 'darwin' ? 'brew' : 'apt-get'
+
+      if (err.message.indexOf('fakeroot') > -1) {
+        err.message = 'Your system is missing the fakeroot package. Try ' + installer + ' install fakeroot'
+      }
+    }
+
     error = error || err
   })
 


### PR DESCRIPTION
Hi @unindented!

Was adding multi-platform installer support to electron-forge with @malept (i.e. "create a debian installer from a mac / darwin machine"), who recommended we provide more helpful error messages if the installer generation fails; this PR is a spike for that work.

This PR is kind of kludge-y, and isn't helpful when e.g. dpkg is not available on the host system. Ideally, a bit more work / thought would happen prior to merge, particularly around the downstream API for errors emitted to the provided callback.

Is this something you've been thinking about / had requests for? If not, is it something you're open to discussing?