### PR TITLE
Properly handle multi-line description and productDescription options

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -200,6 +200,10 @@ var getOptions = function (data, defaults, callback) {
   // Flatten everything for ease of use.
   var options = _.defaults({}, data, data.options, defaults)
 
+  // Replace all newlines in the description with spaces, since it's supposed
+  // to be one line.
+  options.description = options.description.replace(/[\r\n]+/g, ' ')
+
   // Wrap the extended description to avoid lintian warning about
   // `extended-description-line-too-long`.
   options.productDescription = wrap(options.productDescription, {width: 80, indent: ' '})

--- a/src/installer.js
+++ b/src/installer.js
@@ -204,6 +204,8 @@ var getOptions = function (data, defaults, callback) {
   // to be one line.
   options.description = options.description.replace(/[\r\n]+/g, ' ')
 
+  // Ensure blank lines have the "." that denotes a blank line in the control file.
+  options.productDescription = options.productDescription.replace(/^$/m, '.')
   // Wrap the extended description to avoid lintian warning about
   // `extended-description-line-too-long`.
   options.productDescription = wrap(options.productDescription, {width: 80, indent: ' '})

--- a/src/installer.js
+++ b/src/installer.js
@@ -128,7 +128,7 @@ var getDefaults = function (data, callback) {
       genericName: pkg.genericName || pkg.productName || pkg.name,
       description: pkg.description,
       productDescription: pkg.productDescription || pkg.description,
-      // Use '~' on pre-releases for proper debain version ordering.
+      // Use '~' on pre-releases for proper Debian version ordering.
       // See https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
       version: (pkg.version || '0.0.0').replace(/(\d)[_.+-]?((RC|rc|pre|dev|beta|alpha)[_.+-]?\d*)$/, '$1~$2'),
       revision: pkg.revision || '1',

--- a/test/installer.js
+++ b/test/installer.js
@@ -88,4 +88,31 @@ describe('module', function () {
       access(dest + 'bartest_amd64.deb', done)
     })
   })
+
+  describe('with an app with a multi-line description', function (test) {
+    var dest = 'test/fixtures/out/baz/'
+
+    before(function (done) {
+      installer({
+        src: 'test/fixtures/app-without-asar/',
+        dest: dest,
+        rename: function (dest) {
+          return path.join(dest, '<%= name %>_<%= arch %>.deb')
+        },
+
+        options: {
+          description: 'Line one\nLine 2\rLine3\r\nLine 4',
+          arch: 'amd64'
+        }
+      }, done)
+    })
+
+    after(function (done) {
+      rimraf(dest, done)
+    })
+
+    it('generates a `.deb` package', function (done) {
+      access(dest + 'bartest_amd64.deb', done)
+    })
+  })
 })

--- a/test/installer.js
+++ b/test/installer.js
@@ -115,4 +115,31 @@ describe('module', function () {
       access(dest + 'bartest_amd64.deb', done)
     })
   })
+
+  describe('with an app with a productDescription containing a blank line', function (test) {
+    var dest = 'test/fixtures/out/quux/'
+
+    before(function (done) {
+      installer({
+        src: 'test/fixtures/app-without-asar/',
+        dest: dest,
+        rename: function (dest) {
+          return path.join(dest, '<%= name %>_<%= arch %>.deb')
+        },
+
+        options: {
+          productDescription: 'Line one\n\nLine 2 after a blank line',
+          arch: 'amd64'
+        }
+      }, done)
+    })
+
+    after(function (done) {
+      rimraf(dest, done)
+    })
+
+    it('generates a `.deb` package', function (done) {
+      access(dest + 'bartest_amd64.deb', done)
+    })
+  })
 })


### PR DESCRIPTION
Changes:
* Fix typo in comment
* Replace CR/LFs with spaces for `options.description`
* Blank lines in `options.productDescription` have `.` appended to it, per the [Debian Policy Manual](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Description).

Fixes https://github.com/electron-userland/electron-forge/issues/180.