### PR TITLE
Escape the input (URL) with -- (so it won't get mixed up with chromium flags)

### DIFF
--- a/resources/desktop.ejs
+++ b/resources/desktop.ejs
@@ -2,7 +2,7 @@
 <% if (productName) { %>Name=<%= productName %>
 <% } %><% if (description) { %>Comment=<%= description %>
 <% } %><% if (genericName) { %>GenericName=<%= genericName %>
-<% } %><% if (name) { %>Exec=<%= name %> %U
+<% } %><% if (name) { %>Exec=sh -c "<%= name %> -- %U"
 <% } %><% if (name) { %>Icon=<%= name %>
 <% } %>Type=Application
 StartupNotify=true


### PR DESCRIPTION
This PR puts a `--` after the arguments but before the %U (filename) argument.  This is needed to properly handle Chromium flags that get passed through (which also have `--` because of the `--flagName` format)

Needs to be tested with Electron; we use this with our fork of Electron and it works great