### PR TITLE
No longer reference electron-prebuilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Say your Electron app lives in `path/to/app`, and has a structure like this:
 ├── README.md
 ├── node_modules
 │   ├── electron-packager
-│   └── electron-prebuilt
+│   └── electron
 ├── package.json
 ├── resources
 │   ├── Icon.png
@@ -123,7 +123,7 @@ Edit the `scripts` section of your `package.json`:
   "devDependencies": {
     "electron-installer-debian": "*",
     "electron-packager": "*",
-    "electron-prebuilt": "*"
+    "electron": "~1.0.0"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -123,10 +123,13 @@ Edit the `scripts` section of your `package.json`:
   "devDependencies": {
     "electron-installer-debian": "^0.6.0",
     "electron-packager": "^9.0.0",
-    "electron": "~1.0.0"
+    "electron": "^2.0.0"
   }
 }
 ```
+
+_*Note*: The versions in `devDependencies` are examples only, please use the latest package versions
+when possible._
 
 And run the script:
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Edit the `scripts` section of your `package.json`:
   "devDependencies": {
     "electron-installer-debian": "^0.6.0",
     "electron-packager": "^9.0.0",
-    "electron": "^2.0.0"
+    "electron": "~1.7.0"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Edit the `scripts` section of your `package.json`:
     "deb64": "electron-installer-debian --src dist/app-linux-x64/ --dest dist/installers/ --arch amd64"
   },
   "devDependencies": {
-    "electron-installer-debian": "*",
-    "electron-packager": "*",
+    "electron-installer-debian": "^0.6.0",
+    "electron-packager": "^9.0.0",
     "electron": "~1.0.0"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "clean": "rimraf dist",
     "start": "electron .",
-    "exe32": "electron-packager . poopie --platform linux --arch ia32 --out dist/ --ignore \"(dist|node_modules/electron.*)\"",
-    "exe64": "electron-packager . poopie --platform linux --arch x64 --out dist/ --ignore \"(dist|node_modules/electron.*)\"",
+    "exe32": "electron-packager . poopie --platform linux --arch ia32 --out dist/",
+    "exe64": "electron-packager . poopie --platform linux --arch x64 --out dist/",
     "deb32": "electron-installer-debian --src dist/poopie-linux-ia32/ --arch i386 --config config.json",
     "deb64": "electron-installer-debian --src dist/poopie-linux-x64/ --arch amd64 --config config.json",
     "build": "npm run clean && npm run exe32 && npm run deb32 && npm run exe64 && npm run deb64"

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "electron-installer-debian": "^0.6.0",
     "electron-packager": "^9.0.0",
-    "electron": "^2.0.0",
+    "electron": "~1.7.0",
     "rimraf": "^2.6.2"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -20,9 +20,9 @@
     "build": "npm run clean && npm run exe32 && npm run deb32 && npm run exe64 && npm run deb64"
   },
   "devDependencies": {
-    "electron-installer-debian": "*",
-    "electron-packager": "*",
-    "electron-prebuilt": "*",
-    "rimraf": "*"
+    "electron-installer-debian": "^0.6.0",
+    "electron-packager": "^9.0.0",
+    "electron": "~1.7.0",
+    "rimraf": "^2.6.2"
   }
 }

--- a/example/package.json
+++ b/example/package.json
@@ -22,7 +22,7 @@
   "devDependencies": {
     "electron-installer-debian": "^0.6.0",
     "electron-packager": "^9.0.0",
-    "electron": "~1.7.0",
+    "electron": "^2.0.0",
     "rimraf": "^2.6.2"
   }
 }


### PR DESCRIPTION
[It is obsolete](https://electron.atom.io/blog/2016/08/16/npm-install-electron).

Also, don't use `*` as the Electron version. It's simply [not recommended](https://electron.atom.io/docs/tutorial/electron-versioning/#electron-versioning-1).