### PR TITLE
Fix duplicate dependencies when passing options via command-line

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "npm run clean && npm run lint && npm run spec"
   },
   "dependencies": {
-    "asar": "^0.13.0",
+    "asar": "^0.14.0",
     "async": "^2.5.0",
     "debug": "^3.1.0",
     "fs-extra": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test": "npm run clean && npm run lint && npm run spec"
   },
   "dependencies": {
-    "asar": "^0.14.0",
+    "asar": "^0.13.0",
     "async": "^2.5.0",
     "debug": "^3.1.0",
     "fs-extra": "^4.0.2",

--- a/src/installer.js
+++ b/src/installer.js
@@ -246,12 +246,12 @@ var getOptions = function (data, defaults, callback) {
   }
 
   // Create array with unique values from default & user-supplied dependencies
-  if (data.options) {
-    options.depends = _.union(defaults.depends, data.options.depends)
-    options.recommends = _.union(defaults.recommends, data.options.recommends)
-    options.suggests = _.union(defaults.suggests, data.options.suggests)
-    options.enhances = _.uniq(data.options.enhances) // no defaults
-    options.preDepends = _.uniq(data.options.preDepends) // no defaults
+  for (var prop of ['depends', 'recommends', 'suggests', 'enhances', 'preDepends']) {
+    if (data.options) { // options passed programmatically
+      options[prop] = _.union(defaults[prop], data.options[prop])
+    } else { // options passed via command-line
+      options[prop] = _.union(defaults[prop], data[prop])
+    }
   }
 
   callback(null, options)

--- a/test/cli.js
+++ b/test/cli.js
@@ -3,6 +3,8 @@
 var fs = require('fs-extra')
 var access = require('./helpers/access')
 var spawn = require('./helpers/spawn')
+var child = require('child_process')
+var _ = require('lodash')
 
 describe('cli', function () {
   this.timeout(10000)
@@ -40,6 +42,77 @@ describe('cli', function () {
 
     it('generates a `.deb` package', function (done) {
       access(dest + 'bartest_0.0.1_amd64.deb', done)
+    })
+  })
+
+  describe('with duplicate dependencies', function (test) {
+    var dest = 'test/fixtures/out/tjaq/'
+    var config = 'test/fixtures/config.json'
+
+    // Default options (from src/installer.js)
+    var defaults = {
+      depends: ['gvfs-bin',
+        'libgconf2-4',
+        'libgtk2.0-0',
+        'libnotify4',
+        'libnss3',
+        'libxtst6',
+        'xdg-utils'],
+      recommends: ['pulseaudio | libasound2'],
+      suggests: ['gir1.2-gnomekeyring-1.0',
+        'libgnome-keyring0',
+        'lsb-release'],
+      enhances: [],
+      preDepends: []
+    }
+
+    before(function (done) {
+      spawn('./src/cli.js', [
+        '--src', 'test/fixtures/app-with-asar/',
+        '--dest', dest,
+        '--arch', 'i386',
+        '--config', config
+      ], done)
+    })
+
+    after(function (done) {
+      fs.remove(dest, done)
+    })
+
+    it('removes duplicate dependencies', function (done) {
+      access(dest + 'footest_0.0.1_i386.deb', function () {
+        var dpkgDebCmd = 'dpkg-deb -f footest_0.0.1_i386.deb ' +
+          'Depends Recommends Suggests Enhances Pre-Depends'
+        child.exec(dpkgDebCmd, { cwd: dest }, function (err, stdout, stderr) {
+          if (err) return done(err)
+          if (stderr) return done(new Error(stderr.toString()))
+
+          // object with both user and default dependencies based on src/installer.js
+          fs.readJson(config, function (err, configObj) {
+            if (err) return done(err)
+
+            var baseDependencies = {}
+            baseDependencies['Depends'] = _.sortBy(_.union(defaults.depends, configObj.depends))
+            baseDependencies['Recommends'] = _.sortBy(_.union(defaults.recommends, configObj.recommends))
+            baseDependencies['Suggests'] = _.sortBy(_.union(defaults.suggests, configObj.suggests))
+            baseDependencies['Enhances'] = _.sortBy(_.union(defaults.enhances, configObj.enhances))
+            baseDependencies['Pre-Depends'] = _.sortBy(_.union(defaults.preDepends, configObj.preDepends))
+
+            // Creates object based on stdout (values are still strings)
+            var destDependencies = _.fromPairs(_.chunk(_.initial(stdout.split(/\n|:\s/)), 2))
+            // String values are mapped into sorted arrays
+            destDependencies = _.mapValues(destDependencies, function (value) {
+              if (value) return _.sortBy(value.split(', '))
+            })
+
+            if (_.isEqual(baseDependencies, destDependencies)) {
+              done()
+            } else {
+              done(new Error('There are duplicate dependencies'))
+            }
+          })
+        })
+      })
     })
   })
 })

--- a/test/fixtures/config.json
+++ b/test/fixtures/config.json
@@ -1,0 +1,12 @@
+{
+  "productDescription": "Just a test.",
+  "section": "devel",
+  "priority": "optional",
+  "arch": "i386",
+  "depends" : ["libnss3", "libxtst6", "dbus", "dbus"],
+  "recommends" : ["pulseaudio | libasound2", "bzip2", "bzip2"],
+  "suggests" : ["lsb-release", "gvfs", "gvfs"],
+  "enhances" : ["libc6", "libc6"],
+  "preDepends" : ["footest", "footest"],
+  "categories": []
+}


### PR DESCRIPTION
With the new release, I notice that the new behavior on dependencies (append and remove duplicates) does not work when options are loaded via an external `config.json` file or directly using the command-line. This PR fixes that issue.