### PR TITLE
Fix handling executables trying to spawn that don't exist

### DIFF
--- a/src/spawn.js
+++ b/src/spawn.js
@@ -3,7 +3,7 @@
 const spawn = require('cross-spawn-promise')
 
 function updateExecutableMissingException (err, updateError) {
-  if (updateError && err.name === 'ENOENT') {
+  if (updateError && err.code === 'ENOENT') {
     const isFakeroot = err.syscall === 'spawn fakeroot'
     const isDpkg = !isFakeroot && err.syscall === 'spawn dpkg'
 
@@ -11,7 +11,7 @@ function updateExecutableMissingException (err, updateError) {
       const installer = process.platform === 'darwin' ? 'brew' : 'apt-get'
       const pkg = isFakeroot ? 'fakeroot' : 'dpkg'
 
-      err.message = `Your system is missing the fakeroot package. Try, e.g. '${installer} install ${pkg}'`
+      err.message = `Your system is missing the ${pkg} package. Try, e.g. '${installer} install ${pkg}'`
     }
   }
 }
@@ -25,8 +25,9 @@ module.exports = function (cmd, args, logger) {
   return spawn(cmd, args)
     .then(stdout => stdout.toString())
     .catch(err => {
+      const stderr = err.stderr ? err.stderr.toString() : ''
       updateExecutableMissingException(err, !!logger)
 
-      throw new Error(`Error executing command (${err.message || err}):\n${cmd} ${args.join(' ')}\n${err.stderr.toString()}`)
+      throw new Error(`Error executing command (${err.message || err}):\n${cmd} ${args.join(' ')}\n${stderr}`)
     })
 }

--- a/test/spawn.js
+++ b/test/spawn.js
@@ -1,0 +1,29 @@
+'use strict'
+
+const chai = require('chai')
+const spawn = require('../src/spawn')
+
+describe('spawn', () => {
+  let oldPath
+
+  before(() => {
+    oldPath = process.env.PATH
+    process.env.PATH = '/non-existent-path'
+  })
+
+  it('should throw an error when it cannot find an executable', () => {
+    return spawn('does-not-exist', [])
+      .then(() => { throw new Error('does-not-exist should not have existed') })
+      .catch(error => chai.expect(error.message).to.match(/Error executing command/))
+  })
+
+  it('should throw a human-friendly error when it cannot find dpkg or fakeroot', () => {
+    return spawn('dpkg', ['--version'], msg => {})
+      .then(() => { throw new Error('dpkg should not have been executed') })
+      .catch(error => chai.expect(error.message).to.match(/Error executing command \(Your system is missing the dpkg package/))
+  })
+
+  after(() => {
+    process.env.PATH = oldPath
+  })
+})


### PR DESCRIPTION
* `err.stderr` isn't populated
* fix the function that sets the human-readable message
* add tests

Fixes #129.