### PR TITLE
Add support for Electron 2.0 apps

### DIFF
--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -4,34 +4,44 @@ const fs = require('fs-extra')
 const path = require('path')
 const semver = require('semver')
 
+/**
+ * Determine the GTK dependency based on the Electron version in use.
+ */
+function getGTKDepends (version) {
+  return semver.gte(version, '2.0.0-beta.1') ? 'libgtk-3-0' : 'libgtk2.0-0'
+}
+
+/**
+ * Determine the dependencies for the `shell.moveItemToTrash` API, based on the
+ * Electron version in use.
+ */
+function getTrashDepends (version) {
+  if (semver.lt(version, '1.4.1')) {
+    return 'gvfs-bin'
+  } else if (semver.lt(version, '1.7.2')) {
+    return 'kde-cli-tools | kde-runtime | trash-cli | gvfs-bin'
+  } else {
+    return 'kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin'
+  }
+}
+
 module.exports = {
-  /**
-   * Determine the dependencies for the `shell.moveItemToTrash` API, based on the
-   * Electron version in use.
-   */
-  getTrashDepends: function getTrashDepends (options) {
+  getElectronVersion: function getElectronVersion (options) {
     return fs.readFile(path.resolve(options.src, 'version'))
-      .then(tag => {
-        // The content of the version file is the tag name, e.g. "v1.8.1"
-        const version = tag.toString().slice(1).trim()
-        if (semver.lt(version, '1.4.1')) {
-          return 'gvfs-bin'
-        } else if (semver.lt(version, '1.7.2')) {
-          return 'kde-cli-tools | kde-runtime | trash-cli | gvfs-bin'
-        } else {
-          return 'kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin'
-        }
-      })
+      // The content of the version file is the tag name, e.g. "v1.8.1"
+      .then(tag => tag.toString().slice(1).trim())
   },
+  getGTKDepends: getGTKDepends,
+  getTrashDepends: getTrashDepends,
 
   /**
    * Determine the default dependencies for an Electron application.
    */
-  getDepends: function getDepends (trashDependencies) {
+  getDepends: function getDepends (version) {
     return [
-      trashDependencies,
+      getTrashDepends(version),
       'libgconf2-4',
-      'libgtk2.0-0',
+      getGTKDepends(version),
       'libnotify4',
       'libnss3',
       'libxtst6',

--- a/src/installer.js
+++ b/src/installer.js
@@ -75,11 +75,11 @@ function getSize (options) {
  */
 function getDefaults (data) {
   const src = {src: data.src}
-  return Promise.all([readMeta(data), getSize(src), dependencies.getTrashDepends(src)])
+  return Promise.all([readMeta(data), getSize(src), dependencies.getElectronVersion(src)])
     .then(results => {
       const pkg = results[0] || {}
       const size = results[1] || 0
-      const trashDependencies = results[2] || 'gvfs-bin'
+      const electronVersion = results[2]
 
       return {
         name: pkg.name || 'electron',
@@ -97,7 +97,7 @@ function getDefaults (data) {
         arch: undefined,
         size: Math.ceil(size / 1024),
 
-        depends: dependencies.getDepends(trashDependencies),
+        depends: dependencies.getDepends(electronVersion),
         recommends: [
           'pulseaudio | libasound2'
         ],

--- a/test/dependencies.js
+++ b/test/dependencies.js
@@ -1,0 +1,39 @@
+'use strict'
+
+const chai = require('chai')
+const dependencies = require('../src/dependencies')
+
+describe('dependencies', () => {
+  describe('getGTKDepends', () => {
+    it('returns GTK2 pre-2.0', () => {
+      chai.expect(dependencies.getGTKDepends('1.8.2')).to.equal('libgtk2.0-0')
+    })
+
+    it('returns GTK3 as of 2.0', () => {
+      chai.expect(dependencies.getGTKDepends('2.0.0')).to.equal('libgtk-3-0')
+    })
+  })
+
+  describe('getTrashDepends', () => {
+    it('only depends on gvfs-bin before 1.4.1', () => {
+      const trashDepends = dependencies.getTrashDepends('1.3.0')
+      chai.expect(trashDepends).to.match(/gvfs-bin/)
+      chai.expect(trashDepends).to.not.match(/kde-cli-tools/)
+      chai.expect(trashDepends).to.not.match(/libglib2\.0-bin/)
+    })
+
+    it('depends on KDE tools between 1.4.1 and 1.7.1', () => {
+      const trashDepends = dependencies.getTrashDepends('1.6.0')
+      chai.expect(trashDepends).to.match(/gvfs-bin/)
+      chai.expect(trashDepends).to.match(/kde-cli-tools/)
+      chai.expect(trashDepends).to.not.match(/libglib2\.0-bin/)
+    })
+
+    it('depends on glib starting with 1.7.2', () => {
+      const trashDepends = dependencies.getTrashDepends('1.8.2')
+      chai.expect(trashDepends).to.match(/gvfs-bin/)
+      chai.expect(trashDepends).to.match(/kde-cli-tools/)
+      chai.expect(trashDepends).to.match(/libglib2\.0-bin/)
+    })
+  })
+})

--- a/test/helpers/dependencies.js
+++ b/test/helpers/dependencies.js
@@ -7,7 +7,7 @@ const dependencies = require('../../src/dependencies')
 
 // Default options (partly from src/installer.js)
 const defaults = {
-  depends: dependencies.getDepends('gvfs-bin'),
+  depends: dependencies.getDepends('1.0.0'),
   recommends: ['pulseaudio | libasound2'],
   suggests: [
     'gir1.2-gnomekeyring-1.0',


### PR DESCRIPTION
Electron 2.0 (well, [Electron 2.0.0-beta.1](https://github.com/electron/electron/releases/tag/v2.0.0-beta.1) currently) uses GTK3 instead of GTK2.

Also, add tests for the dependencies module.

I have to do the same thing for three more Linux distributable modules :cry: 