### PR TITLE
Add transformVersion as an exportable function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ addons:
       - fakeroot
       - lintian
 
+before_script: chmod -R g-w test/fixtures
+
 deploy:
   provider: npm
   email: unindented@gmail.com

--- a/src/installer.js
+++ b/src/installer.js
@@ -70,6 +70,16 @@ function getSize (options) {
 }
 
 /**
+ * Transforms a SemVer version into a Debian-style version.
+ *
+ * Use '~' on pre-releases for proper Debian version ordering.
+ * See https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
+ */
+function transformVersion (version) {
+  return version.replace(/(\d)[_.+-]?((RC|rc|pre|dev|beta|alpha)[_.+-]?\d*)$/, '$1~$2')
+}
+
+/**
  * Get the hash of default options for the installer. Some come from the info
  * read from `package.json`, and some are hardcoded.
  */
@@ -87,9 +97,7 @@ function getDefaults (data) {
         genericName: pkg.genericName || pkg.productName || pkg.name,
         description: pkg.description,
         productDescription: pkg.productDescription || pkg.description,
-        // Use '~' on pre-releases for proper Debian version ordering.
-        // See https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
-        version: (pkg.version || '0.0.0').replace(/(\d)[_.+-]?((RC|rc|pre|dev|beta|alpha)[_.+-]?\d*)$/, '$1~$2'),
+        version: transformVersion(pkg.version || '0.0.0'),
         revision: pkg.revision || '1',
 
         section: 'utils',
@@ -436,3 +444,5 @@ module.exports = data => {
       throw err
     })
 }
+
+module.exports.transformVersion = transformVersion

--- a/test/installer.js
+++ b/test/installer.js
@@ -250,4 +250,11 @@ describe('module', function () {
       process.umask(defaultMask)
     })
   })
+
+  describe('transformVersion', () => {
+    it('uses tildes for pre-release versions', () => {
+      chai.expect(installer.transformVersion('1.2.3')).to.equal('1.2.3')
+      chai.expect(installer.transformVersion('1.2.3-beta.4')).to.equal('1.2.3~beta.4')
+    })
+  })
 })


### PR DESCRIPTION
Allows other modules to transform a SemVer version into a Debian-style version.

I'd like to add this because it's needed to fix [an Electron Forge bug](https://github.com/electron-userland/electron-forge/issues/583).